### PR TITLE
Fix group ID on inferenceql.inference dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
         org.clojure/spec.alpha {:mvn/version "0.3.218"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.36"} ; needed so tablesaw doesn't log
-        probcomp/inferenceql.inference {:git/url "https://github.com/OpenIQL/inferenceql.inference.git" :git/sha "6938e350673f93bc8383975d92e305ff6872cf61"}
+        openiql/inferenceql.inference {:git/url "https://github.com/OpenIQL/inferenceql.inference.git" :git/sha "6938e350673f93bc8383975d92e305ff6872cf61"}
         probcomp/metaprob {:git/url "https://github.com/probcomp/metaprob.git" :git/sha "8dc9d09f747c1e29886bb9628a0110c6f6bc6f5a"}
         rhizome/rhizome {:mvn/version "0.2.9"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}


### PR DESCRIPTION
## Overview

This pull request fixes the group ID for the inferenceql.inference dependency. 

## Motivation

While it seems that the group ID is purely cosmetic for git dependencies it still serves a purpose as documentation.