### PR TITLE
Remove dependency on hashp

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:deps {borkdude/sci {:mvn/version "0.2.7"}
         cljs-bean/cljs-bean {:mvn/version "1.8.0"}
-        hashp/hashp {:mvn/version "0.2.1"}
         instaparse/instaparse {:mvn/version "1.4.12"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/muuntaja {:mvn/version "0.6.8"}

--- a/src/inferenceql/query.cljc
+++ b/src/inferenceql/query.cljc
@@ -2,12 +2,11 @@
   "This file defines functions for parsing, transforming, and executing IQL-SQL
   queries."
   (:refer-clojure :exclude [eval])
-  (:require [hashp.core]
-            #?(:clj [inferenceql.query.command :as command])
+  (:require #?(:clj [inferenceql.query.command :as command])
             [inferenceql.query.db :as db]
             [inferenceql.query.error :as error]
-            [inferenceql.query.permissive.parser :as parser]
             [inferenceql.query.permissive :as permissive]
+            [inferenceql.query.permissive.parser :as parser]
             [inferenceql.query.plan :as plan]
             [inferenceql.query.relation :as relation]
             [inferenceql.query.statement :as statement]

--- a/src/inferenceql/query/scalar.cljc
+++ b/src/inferenceql/query/scalar.cljc
@@ -4,7 +4,6 @@
             [clojure.edn :as edn]
             [clojure.spec.alpha :as s]
             [clojure.walk :as walk]
-            [hashp.core]
             ;; [inferenceql.inference.search.crosscat :as crosscat]
             [inferenceql.inference.approximate :as approx]
             [inferenceql.inference.gpm :as gpm]


### PR DESCRIPTION
## Overview

This pull request removes the dependency on [hashp](https://github.com/weavejester/hashp).

## Motivation

hashp is used for debugging. It should never have been committed. It also triggers a warning on startup due to an issue with a transitive dependency. See #16.

```
WARNING: abs already refers to: #'clojure.core/abs in namespace: zprint.range, being replaced by: #'zprint.range/abs
```