### PR TITLE
Remove specs, dependency on spec.alpha

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,6 @@
         org.clojure/core.match {:mvn/version "1.0.0"}
         org.clojure/data.csv {:mvn/version "1.0.1"}
         org.clojure/math.combinatorics {:mvn/version "0.1.6"}
-        org.clojure/spec.alpha {:mvn/version "0.3.218"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.36"} ; needed so tablesaw doesn't log
         probcomp/metaprob {:git/url "https://github.com/probcomp/metaprob.git" :git/sha "8dc9d09f747c1e29886bb9628a0110c6f6bc6f5a"}

--- a/src/inferenceql/query/environment.cljc
+++ b/src/inferenceql/query/environment.cljc
@@ -1,7 +1,6 @@
 (ns inferenceql.query.environment
   (:refer-clojure :exclude [get])
-  (:require [clojure.core :as clojure]
-            [clojure.spec.alpha :as s]))
+  (:require [clojure.core :as clojure]))
 
 (defn get
   "Look up a symbol in an environment."
@@ -33,6 +32,3 @@
 (defn ->map
   [env]
   env)
-
-(s/def ::env env?)
-(s/def ::sym symbol?)

--- a/src/inferenceql/query/model.cljc
+++ b/src/inferenceql/query/model.cljc
@@ -1,4 +1,0 @@
-(ns inferenceql.query.model
-  (:require [clojure.spec.alpha :as s]))
-
-(s/def ::variable symbol?)

--- a/src/inferenceql/query/relation.cljc
+++ b/src/inferenceql/query/relation.cljc
@@ -2,7 +2,6 @@
   "Functions for creating and manipulating relations."
   (:refer-clojure :exclude [distinct empty group-by name sort transduce])
   (:require [clojure.core :as clojure]
-            [clojure.spec.alpha :as s]
             [inferenceql.query.tuple :as tuple]
             [medley.core :as medley]))
 
@@ -127,7 +126,3 @@
     (into [attrs]
           (mapv (comp vec tuple/->vector)
                 (tuples rel)))))
-
-(s/def ::name symbol?)
-(s/def ::attribute symbol?)
-(s/def ::relation relation?)

--- a/src/inferenceql/query/scalar.cljc
+++ b/src/inferenceql/query/scalar.cljc
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [eval])
   (:require [clojure.core.match :as match]
             [clojure.edn :as edn]
-            [clojure.spec.alpha :as s]
             [clojure.walk :as walk]
             ;; [inferenceql.inference.search.crosscat :as crosscat]
             [inferenceql.inference.approximate :as approx]
@@ -13,12 +12,6 @@
             [inferenceql.query.tuple :as tuple]
             [medley.core :as medley]
             [sci.core :as sci]))
-
-(s/def ::plan
-  (s/or :scalar (s/or :number number? :string string? :keyword keyword? :symbol symbol?)
-        :map (s/map-of keyword? ::plan)
-        :vector (s/and vector? (s/coll-of ::plan))
-        :function-application (s/and (some-fn seq? list?) (s/cat :function symbol? :args (s/* ::plan)))))
 
 (defn plan
   [node]


### PR DESCRIPTION
## Overview

1. Remove all the specs, many of which are oudated.
1. Remove the dependency on `org.clojure/spec.alpha`.

## Motivation

The specs are outdated and are no longer used anywhere.