### PR TITLE
Bump inferenceql.inference

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,8 +5,8 @@
         metosin/muuntaja {:mvn/version "0.6.8"}
         net.cgrand/macrovich {:mvn/version "0.2.1"}
         net.cgrand/xforms {:mvn/version "0.19.2"}
-        org.clojure/clojure {:mvn/version "1.11.1"}
         openiql/inferenceql.inference {:git/url "https://github.com/OpenIQL/inferenceql.inference.git" :git/sha "cce44b173558d7ed95b5c6c9b91e74c809843ed3"}
+        org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/clojurescript {:mvn/version "1.11.54"}
         org.clojure/core.match {:mvn/version "1.0.0"}
         org.clojure/data.csv {:mvn/version "1.0.1"}


### PR DESCRIPTION
## Overview

- Bump inferenceql.inference.
- Sort the dependencies in `deps.edn`.

## Motivation

- We would like to take advantage of the fix in OpenIQL/inferenceql.inference#8.