### PR TITLE
build: Bump ClojureScript

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
         net.cgrand/xforms {:mvn/version "0.19.2"}
         openiql/inferenceql.inference {:git/url "https://github.com/OpenIQL/inferenceql.inference.git" :git/sha "cce44b173558d7ed95b5c6c9b91e74c809843ed3"}
         org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/clojurescript {:mvn/version "1.11.54"}
+        org.clojure/clojurescript {:mvn/version "1.11.60"}
         org.clojure/core.match {:mvn/version "1.0.0"}
         org.clojure/data.csv {:mvn/version "1.0.1"}
         org.clojure/math.combinatorics {:mvn/version "0.1.6"}


### PR DESCRIPTION
## Overview

Bumps ClojureScript from 1.11.54 to 1.11.60.

## Motivation

See the [ClojureScript changelog](https://github.com/clojure/clojurescript/blob/master/changes.md).
