### PR TITLE
Use `clojure.core/exp`

### DIFF
--- a/src/inferenceql/query/math.cljc
+++ b/src/inferenceql/query/math.cljc
@@ -1,10 +1,5 @@
 (ns inferenceql.query.math)
 
-(defn exp
-  "Returns Euler's number e raised to the power of a double value."
-  [x]
-  (Math/exp x))
-
 (defn median
   "Computes the median of the numerical values in a collection."
   [coll]

--- a/src/inferenceql/query/scalar.cljc
+++ b/src/inferenceql/query/scalar.cljc
@@ -2,11 +2,11 @@
   (:refer-clojure :exclude [eval])
   (:require [clojure.core.match :as match]
             [clojure.edn :as edn]
+            [clojure.math :as math]
             [clojure.walk :as walk]
             ;; [inferenceql.inference.search.crosscat :as crosscat]
             [inferenceql.inference.approximate :as approx]
             [inferenceql.inference.gpm :as gpm]
-            [inferenceql.query.math :as math]
             [inferenceql.query.parser.tree :as tree]
             [inferenceql.query.relation :as relation]
             [inferenceql.query.tuple :as tuple]


### PR DESCRIPTION
## Overview

* Remove `inferenceql.query.math/exp`.
* Replace calls to `inferenceql.query.math` with calls to `clojure.math/exp`.

## Motivation

Using functions from the standard library will reduce our maintenance burden. 