### PR TITLE
Fix warning and improve readability in GitHub actions workflows

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -8,12 +8,15 @@ jobs:
         uses: DeLaGuardo/setup-clj-kondo@master
         with:
           version: '2022.04.25'
+
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Cache clj-kondo cache
         uses: actions/cache@v2
         with:
           path: .clj-kondo/.cache
           key: clj-kondo-cache-${{ hashFiles('deps.edn') }}
+
       - name: Lint files
         run: clj-kondo --lint src test --dependencies --config .clj-kondo/ci-config.edn

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,31 +9,41 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+
       - name: Setup Clojure tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: 1.10.3.1040
+
       - name: Setup node
         uses: actions/setup-node@v2
+
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Install ws
         run: npm install ws
+
       - name: Cache m2
         uses: actions/cache@v2
         with:
           path: ~/.m2
           key: m2-${{ hashFiles('deps.edn') }}
+
       - name: Cache gitlibs
         uses: actions/cache@v2
         with:
           path: ~/.gitlibs
           key: gitlibs-${{ hashFiles('deps.edn') }}
+
       - name: Prepare dependencies
         run: clojure -M:test:clj-test:cljs-test:readme-test -P
+
       - name: Run Clojure tests
         run: clojure -X:test:clj-test
+
       - name: Run ClojureScript tests
         run: clojure -M:test:cljs-test
+
       - name: Run README tests
         run: clojure -M:test:readme-test


### PR DESCRIPTION
## Overview

* Adds whitespace between the steps in both GitHub actions workflows.
* Renames the `tools-deps` key to `cli` key in the `setup-clojure` task as the latter is deprecated.

## Motivation

This fixes [a warning](https://github.com/InferenceQL/inferenceql.query/runs/7324013635?check_suite_focus=true#step:3:1) in the Clojure tests CI workflow:
```
Warning: Input 'tools-deps' has been deprecated with message: Use the `cli` input instead
```