### PR TITLE
Bump sci

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
-{:deps {borkdude/sci {:mvn/version "0.2.7"}
-        cljs-bean/cljs-bean {:mvn/version "1.8.0"}
+{:deps {cljs-bean/cljs-bean {:mvn/version "1.8.0"}
         instaparse/instaparse {:mvn/version "1.4.12"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/muuntaja {:mvn/version "0.6.8"}
         net.cgrand/macrovich {:mvn/version "0.2.1"}
         net.cgrand/xforms {:mvn/version "0.19.2"}
         openiql/inferenceql.inference {:git/url "https://github.com/OpenIQL/inferenceql.inference.git" :git/sha "cce44b173558d7ed95b5c6c9b91e74c809843ed3"}
+        org.babashka/sci {:mvn/version "0.3.32"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/clojurescript {:mvn/version "1.11.60"}
         org.clojure/core.match {:mvn/version "1.0.0"}


### PR DESCRIPTION
## Overview

Bump sci to `0.3.32`.

## Motivation

This is absolutely bizarre, but on sci 0.2.7 `sci.core/eval-string` hangs if [reitit](https://github.com/metosin/reitit) is on the classpath. 

Weirdly, you don’t even need to require reitit to reproduce the issue:

```
❯ nix-shell --pure  -p clojure

[nix-shell:~]$ timeout -v 60 clojure -Srepro -Sdeps '{:deps {metosin/reitit {:mvn/version "0.5.18"} org.babashka/sci {:mvn/version "0.2.7"}}}' -M -e "(require '[sci.core :as sci]) (sci/eval-string \"0\")"

timeout: sending signal TERM to command 'clojure'
```

Works fine if reitit is excluded:

```
[nix-shell:~]$ time clojure -Srepro -Sdeps '{:deps {org.babashka/sci {:mvn/version "0.2.7"}}}' -M -e "(require '[sci.core :as sci]) (sci/eval-string \"0\")"
0

real	0m4.011s
user	0m14.914s
sys	0m0.576s
```

The issue was fixed in sci `0.2.8`:

```
[nix-shell:~]$ time clojure -Srepro -Sdeps '{:deps {metosin/reitit {:mvn/version "0.5.18"} org.babashka/sci {:mvn/version "0.2.8"}}}' -M -e "(require '[sci.core :as sci]) (sci/eval-string \"0\")"
0

real	0m4.263s
user	0m15.740s
sys	0m0.657s
```

Simply requiring sci is fine, even with reitit:

```
[nix-shell:~]$ time clojure -Srepro -Sdeps '{:deps {metosin/reitit {:mvn/version "0.5.18"} org.babashka/sci {:mvn/version "0.2.7"}}}' -M -e "(require '[sci.core :as sci])"

real	0m4.255s
user	0m20.633s
sys	0m0.658s
```