### PR TITLE
Fix evaluation of repeatable scalar expressions

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -125,18 +125,18 @@ scalar-expr ::= scalar-expr-0
 <scalar-expr-4> ::= scalar-expr-5 | expr-addition | expr-subtraction
 <scalar-expr-5> ::= scalar-expr-6 | expr-multiplication | expr-division
 
-expr-disjunction ::= scalar-expr-1 (ws #'(?i)OR'  ws scalar-expr-1)+
-expr-conjunction ::= scalar-expr-2 (ws #'(?i)AND' ws scalar-expr-2)+
+expr-disjunction ::= scalar-expr-0 ws #'(?i)OR'  ws scalar-expr-1
+expr-conjunction ::= scalar-expr-1 ws #'(?i)AND' ws scalar-expr-2
 
 expr-not ::= #'(?i)NOT' ws scalar-expr-3
 
-expr-binop ::= scalar-expr-3 (ws? binop ws? scalar-expr-4)+
+expr-binop ::= scalar-expr-3 ws? binop ws? scalar-expr-4
 
-expr-addition    ::= scalar-expr-4 (ws? '+' ws? scalar-expr-5)+
-expr-subtraction ::= scalar-expr-4 (ws? '-' ws? scalar-expr-5)+
+expr-addition    ::= scalar-expr-4 ws? '+' ws? scalar-expr-5
+expr-subtraction ::= scalar-expr-4 ws? '-' ws? scalar-expr-5
 
-expr-multiplication ::= scalar-expr-5 (ws? '*' ws? scalar-expr-6)+
-expr-division       ::= scalar-expr-5 (ws? '/' ws? scalar-expr-6)+
+expr-multiplication ::= scalar-expr-5 ws? '*' ws? scalar-expr-6
+expr-division       ::= scalar-expr-5 ws? '/' ws? scalar-expr-6
 
 scalar-expr-group ::= '(' ws? scalar-expr ws? ')'
 

--- a/test/inferenceql/query/scalar_test.cljc
+++ b/test/inferenceql/query/scalar_test.cljc
@@ -6,96 +6,151 @@
             [inferenceql.query.scalar :as scalar]
             [inferenceql.query.tuple :as tuple]))
 
-(deftest expr->sexpr
-  (are [expr sexpr] (= sexpr (scalar/plan (parser/parse expr :start :scalar-expr)))
-    "x"              'x
-    "not x"          '(not x)
+(defn plan
+  [s]
+  (-> (parser/parse s :start :scalar-expr)
+      (scalar/plan)))
 
-    "x > y"          '(> x y)
-    "x > y > z"      '(> (> x y) z)
+(deftest plan-symbol
+  (is (= 'x (plan "x"))))
 
-    "x = 0"          '(= x 0)
-    "x = y = 0"      '(= (= x y) 0)
+(deftest plan-operator
+  (are [s sexpr] (= sexpr (plan s))
+    "x or y" '(or x y)
+    "x and y" '(and x y)
+    "not x" '(not x)
+    "x > y" '(> x y)
+    "x >= y" '(>= x y)
+    "x = 0" '(= x 0)
+    "x <= y" '(<= x y)
+    "x < y" '(< x y)
+    "x + y" '(+ x y)
+    "x - y" '(- x y)
+    "x * y" '(* x y)
+    "x / y" '(/ x y)))
 
-    "x and y or z"   '(or (and x y) z)
-    "x or y and z"   '(or x (and y z))
+(deftest plan-operator-precedence-same
+  (are [s sexpr] (= sexpr (plan s))
+    "x or y or z" '(or (or x y) z)
+    "x and y and z" '(and (and x y) z)
+    "x + y + z" '(+ (+ x y) z)
+    "x - y - z" '(- (- x y) z)
+    "x * y * z" '(* (* x y) z)
+    "x / y / z" '(/ (/ x y) z)
+    "x > y > z" '(> (> x y) z)
+    "x >= y >= z" '(>= (>= x y) z)
+    "x = y = z" '(= (= x y) z)
+    "x <= y <= z" '(<= (<= x y) z)
+    "x < y < z" '(< (< x y) z)
+    "x is y is z" '(= (= x y) z)))
+
+(deftest plan-operator-precedence-different
+  (are [s sexpr] (= sexpr (plan s))
+    "x and y or z" '(or (and x y) z)
+    "x or y and z" '(or x (and y z))
+    "not x and y" '(and (not x) y)
+    "not x or y" '(or (not x) y)
+    "not x = y" '(not (= x y))
+    "x = y + z" '(= x (+ y z))
+    "x + y = z" '(= (+ x y) z)
+    "x + y * z" '(+ x (* y z))
+    "x * y + z" '(+ (* x y) z)))
+
+(deftest plan-operator-group
+  (are [s sexpr] (= sexpr (plan s))
     "x and (y or z)" '(and x (or y z))
     "(x or y) and z" '(and (or x y) z)
-
-    "x * y + z"      '(+ (* x y) z)
-    "x + y * z"      '(+ x (* y z))
-    "x * (y + z)"    '(* x (+ y z))
-    "(x + y) * z"    '(* (+ x y) z)))
+    "(not x) and y" '(and (not x) y)
+    "(not x) or y" '(or (not x) y)
+    "(not x) = y" '(= (not x) y)
+    "(x = y) + z" '(+ (= x y) z)
+    "x + (y = z)" '(+ x (= y z))
+    "(x + y) * z" '(* (+ x y) z)
+    "x * (y + z)" '(* x (+ y z))))
 
 (defn eval
-  ([s env & tuples]
-   (let [plan (-> (parser/parse s :start :scalar-expr)
-                  (scalar/plan))]
-     (apply scalar/eval plan env {} tuples))))
+  [expr env & tuples]
+  (apply scalar/eval (plan expr) env {} tuples))
 
-(deftest symbols
-  (testing "no tuples"
-    (is (= 0 (eval "x" '{x 0}))))
+(deftest eval-symbol-env
+  (are [s env expected] (= expected
+                           (try (eval s env)
+                                (catch #?(:clj Exception :cljs :default) e
+                                  :error)))
+    "x" '{x 0} 0
+    "x" '{} :error))
 
-  (testing "tuples"
-    (are [expected s env m attrs name] (= expected
-                                          (eval s env (tuple/tuple m :name name :attrs attrs)))
-      nil "x"      '{}    '{}    '[x] 'data
-      nil "data.x" '{}    '{}    '[x] 'data
-      0   "x"      '{x 0} '{}    '[x] 'data
-      0   "x"      '{}    '{x 0} '[x] 'data
-      0   "data.x" '{}    '{x 0} '[x] 'data)))
+(deftest eval-symbol-tuple
+  (are [expected s env m attrs name] (let [tuple (tuple/tuple m :name name :attrs attrs)]
+                                       (= expected (eval s env tuple)))
+    nil "x" '{} '{} '[x] 'data
+    nil "data.x" '{} '{} '[x] 'data
+    0 "x" '{x 0} '{} '[x] 'data
+    0 "x" '{} '{x 0} '[x] 'data
+    0 "data.x" '{} '{x 0} '[x] 'data))
 
-(deftest evaluation
+(deftest eval-operator-no-env
+  (are [expected s] (= expected (eval s {}))
+    false "NOT true"
+    true "NOT false"
+
+    true "0 IS 0"
+    false "0 IS 1"
+    false "1 IS 0"
+
+    false "0 IS NOT 0"
+    true "0 IS NOT 1"
+    true "1 IS NOT 0"
+
+    true "NULL IS NULL"
+    false "NULL IS NOT NULL"
+    false "0 IS NULL"
+    true  "0 IS NOT NULL"))
+
+(deftest eval-operator-env
+  (are [expected s env] (= expected
+                           (try (eval s env)
+                                (catch #?(:clj Exception :cljs :default) _
+                                  :error)))
+    0 "x" '{x 0}
+    :error "x" '{}
+
+    true "x IS 0" '{x 0}
+    false "x IS 0" '{x 1}
+    true "0 IS x" '{x 0}
+    false "0 IS x" '{x 1}
+
+    false "x IS NOT 0" '{x 0}
+    true "x IS NOT 0" '{x 1}
+    false "0 IS NOT x" '{x 0}
+    true    "0 IS NOT x"    '{x 1}
+
+    :error "x IS NULL" '{}
+    false "x IS NOT NULL" '{x nil}
+    false "x IS NOT NULL" '{x nil}
+    false "x IS NULL" '{x 0}
+    true "x IS NOT NULL" '{x 0}))
+
+(deftest eval-operator-tuple
   (are [expected s env m attrs] (= expected
                                    (let [tuple (tuple/tuple m :attrs attrs)]
                                      (try (eval s env tuple)
                                           (catch #?(:clj Exception :cljs :default) _
                                             :error))))
-    false   "NOT true"         '{}      '{}      '[]
-    true    "NOT false"        '{}      '{}      '[]
+    true "x IS NULL" '{x nil} '{} '[x]
+    true "x IS NULL" '{} '{x nil} '[x]
 
-    true    "0 IS 0"           '{}      '{}      '[]
-    false   "0 IS 1"           '{}      '{}      '[]
-    false   "1 IS 0"           '{}      '{}      '[]
-    true    "x IS 0"           '{x 0}   '{}      '[]
-    false   "x IS 0"           '{x 1}   '{}      '[]
-    true    "0 IS x"           '{x 0}   '{}      '[]
-    false   "0 IS x"           '{x 1}   '{}      '[]
+    1 "x + 1" '{} '{x 0} '[x]
+    nil "x + 1" '{} '{} '[x]))
 
-    false   "0 IS NOT 0"       '{}      '{}      '[]
-    true    "0 IS NOT 1"       '{}      '{}      '[]
-    true    "1 IS NOT 0"       '{}      '{}      '[]
-    false   "x IS NOT 0"       '{x 0}   '{}      '[]
-    true    "x IS NOT 0"       '{x 1}   '{}      '[]
-    false   "0 IS NOT x"       '{x 0}   '{}      '[]
-    true    "0 IS NOT x"       '{x 1}   '{}      '[]
-
-    true    "NULL IS NULL"     '{}      '{}      '[]
-    false   "NULL IS NOT NULL" '{}      '{}      '[]
-    false   "0 IS NULL"        '{}      '{}      '[]
-    true    "0 IS NOT NULL"    '{}      '{}      '[]
-    true    "x IS NULL"        '{x nil} '{}      '[]
-    true    "x IS NULL"        '{x nil} '{}      '[x]
-    true    "x IS NULL"        '{}      '{x nil} '[x]
-    :error  "x IS NULL"        '{}      '{}      '[]
-    false   "x IS NOT NULL"    '{x nil} '{}      '[]
-    false   "x IS NOT NULL"    '{x nil} '{}      '[]
-    false   "x IS NULL"        '{x 0}   '{}      '[]
-    true    "x IS NOT NULL"    '{x 0}   '{}      '[]
-
-    1       "x + 1"            '{}      '{x 0}   '[x]
-    nil     "x + 1"            '{}      '{}      '[x]
-    :error  "x + 1"            '{}      '{}      '[]))
-
-(deftest mutual-info
+(deftest eval-mutual-info
   (let [model (reify gpm.proto/MutualInfo
                 (mutual-info [_ _ _]
                   7))
         env {'model model}]
     (is (= 7 (eval "MUTUAL INFORMATION OF VAR x > 0 WITH VAR x < 0 UNDER model" env)))))
 
-(deftest approx-mutual-info
+(deftest eval-approximate-mutual-info
   (let [simulate-count (atom 0)
         model (reify gpm.proto/GPM
                 (simulate [_this _targets _constraints]


### PR DESCRIPTION
## Overview

Change the grammar for "repeatable" scalar expressions to remove one-or-more matching (`+`). Repeated expressions will instead be handled by recursive production rules.

## Motivation

Currently evaluation of "repeatable" scalar expressions of length three or more that share the same operator fail. For instance:

```
x OR y OR z
x AND y AND z
x + y + z
```
