### PR TITLE
Remove transitive dependency on Incanter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,4 @@
 {:skip-comments true
  :lint-as {clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all clojure.core/let
-           metaprob.generative-functions/gen clojure.core/fn
            inferenceql.query.parser.tree/match clojure.core.match/match}}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,6 @@
         org.clojure/math.combinatorics {:mvn/version "0.1.6"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.36"} ; needed so tablesaw doesn't log
-        probcomp/metaprob {:git/url "https://github.com/probcomp/metaprob.git" :git/sha "8dc9d09f747c1e29886bb9628a0110c6f6bc6f5a"}
         rhizome/rhizome {:mvn/version "0.2.9"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         ring/ring-core {:mvn/version "1.9.5"}


### PR DESCRIPTION
## Overview

* Bumps inferenceql.inference to a version that no longer transitively depends on Incanter.
* Removes the direct dependency on Metaprob.

## Motivation

Should resolve #16.