### PR TITLE
 feat: Add SQL's SUM aggregator

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -105,7 +105,7 @@ limit-clause ::= #'(?i)LIMIT' ws int
 (* aggregation *)
 
 aggregation ::= aggregation-fn ws? '(' (distinct-clause ws)? ws? (star / simple-symbol) ws? ')' (ws alias-clause)?
-aggregation-fn ::= count | avg | median | std | max | min
+aggregation-fn ::= count | avg | median | std | max | min | sum
 
 count  ::= #'(?i)COUNT'
 avg    ::= #'(?i)AVG'
@@ -113,6 +113,7 @@ std    ::= #'(?i)STD'
 median ::= #'(?i)MEDIAN'
 max    ::= #'(?i)MAX'
 min    ::= #'(?i)MIN'
+sum    ::= #'(?i)SUM'
 
 (* scalar-expr *)
 

--- a/src/inferenceql/query/plan.cljc
+++ b/src/inferenceql/query/plan.cljc
@@ -539,6 +539,7 @@
 (def ^:private agg-f
   (-> {'count xforms/count
        'avg xforms/avg
+       'sum (xforms/reduce +)
        'median query.xforms/median
        'std xforms/sd
        'max xforms/max

--- a/test/inferenceql/query/plan_test.cljc
+++ b/test/inferenceql/query/plan_test.cljc
@@ -99,7 +99,7 @@
     "ALTER data ADD y" '[x]   '[x y]
     "ALTER data ADD z" '[x y] '[x y z]))
 
-(deftest aggregation
+(deftest aggregation-max
   (are [query in out] (= out (->> (eval query {'data in})
                                   (relation/tuples)
                                   (map tuple/->vector)))
@@ -112,6 +112,20 @@
     "SELECT max(x), min(x) FROM data"    '[{x 0} {x 1}]                             '[[1 0]]
     "SELECT max(x), max(y) FROM data"    '[{x 0 y 1} {x 1 y 0}]                     '[[1 1]]
     "SELECT max(x) FROM data GROUP BY y" '[{x 0 y 0} {x 1 y 1} {x 2 y 0} {x 3 y 1}] '[[2] [3]]))
+
+(deftest aggregation-sum
+  (are [query in out] (= out (->> (eval query {'data in})
+                                  (relation/tuples)
+                                  (map tuple/->vector)))
+    "SELECT sum(x) FROM data"            '[]                                        '[[nil]]
+    "SELECT sum(x) FROM data"            '[{x 0} {x 1}]                             '[[1]]
+    "SELECT sum(x) FROM data"            '[{x 1} {x 0}]                             '[[1]]
+    "SELECT sum(x) FROM data"            '[{x 0} {x 1} {x 2}]                       '[[3]]
+    "SELECT sum(x) FROM data"            '[{x 0} {x 2} {x 1}]                       '[[3]]
+    "SELECT sum(x) FROM data"            '[{x 2} {x 1} {x 0}]                       '[[3]]
+    "SELECT sum(x), min(x) FROM data"    '[{x 0} {x 1}]                             '[[1 0]]
+    "SELECT sum(x), sum(y) FROM data"    '[{x 1 y 1} {x 2 y 0}]                     '[[3 1]]
+    "SELECT sum(x) FROM data GROUP BY y" '[{x 0 y 0} {x 1 y 1} {x 2 y 0} {x 3 y 1}] '[[2] [4]]))
 
 (deftest count
   (testing "count(x)"


### PR DESCRIPTION
## What does this do?

Adds SQL's `SUM` aggregator (see e.g. [MySQL](https://www.w3schools.com/sql/func_mysql_sum.asp)).

## How was this tested?

Tested by running `SELECT SUM(foo) from data` in the IQL-REPL.