### PR TITLE
Add aggregator to compute the percentile of value x in column y

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -100,8 +100,13 @@ limit-clause ::= #'(?i)LIMIT' ws int
 
 (* aggregation *)
 
-aggregation ::= aggregation-fn ws? '(' (distinct-clause ws)? ws? (star / simple-symbol) ws? ')' (ws alias-clause)?
-aggregation-fn ::= count | avg | median | std | max | min | sum
+aggregation ::= aggregation-fn-0 ws? '(' (distinct-clause ws)? ws? (star / aggregation-target) ws? ')' (ws alias-clause)?
+
+<aggregation-target> ::= simple-symbol | simple-symbol ws? ',' ws? value
+
+<aggregation-fn-0>   ::= aggregation-fn |  aggregation-fn-param
+aggregation-fn       ::= count | avg | median | std | max | min | sum
+aggregation-fn-param ::= percentile_in
 
 count  ::= #'(?i)COUNT'
 avg    ::= #'(?i)AVG'
@@ -110,6 +115,8 @@ median ::= #'(?i)MEDIAN'
 max    ::= #'(?i)MAX'
 min    ::= #'(?i)MIN'
 sum    ::= #'(?i)SUM'
+
+percentile_in ::= #'(?i)percentile_in'
 
 (* scalar-expr *)
 

--- a/src/inferenceql/query/math.cljc
+++ b/src/inferenceql/query/math.cljc
@@ -14,3 +14,6 @@
             top-val (nth sorted halfway)]
         (/ (+ bottom-val top-val)
            2)))))
+
+(defn percentile-in [v s]
+  (* 100.0 (/ (.indexOf (sort (conj s v)) v) (count s))))

--- a/src/inferenceql/query/xforms.cljc
+++ b/src/inferenceql/query/xforms.cljc
@@ -12,3 +12,15 @@
       ([acc input]
        (vswap! coll conj input)
        acc))))
+
+(defn make-percentile [v]
+  (fn [xf]
+    (let [coll (volatile! [])]
+      (fn
+        ([]
+         (xf))
+        ([acc]
+         (xf acc (math/percentile-in v @coll)))
+        ([acc input]
+         (vswap! coll conj input)
+         acc)))))

--- a/test/inferenceql/query/plan_test.cljc
+++ b/test/inferenceql/query/plan_test.cljc
@@ -195,6 +195,24 @@
       "SELECT avg(DISTINCT x) FROM data" '[{x 0} {x 0} {x 1}] 0.5
       "SELECT avg(DISTINCT x) FROM data" '[{x 0} {x 1} {x 1}] 0.5)))
 
+(deftest percentile_in
+  (are [query in out] (= out (->> (eval query {'data in})
+                                  (relation/tuples)
+                                  (map tuple/->vector)))
+    "SELECT percentile_in(x, 0) FROM data"            '[]                                                             '[[nil]]
+    "SELECT percentile_in(x, 0) FROM data"            '[{x 0} {x 1}]                                                  '[[0.0]]
+    "SELECT percentile_in(x, 0.0) FROM data"          '[{x 0.0} {x 1.0}]                                              '[[0.0]]
+    "SELECT percentile_in(x, 1) FROM data"            '[{x 0} {x 1}]                                                  '[[50.0]]
+    "SELECT percentile_in(x, 2) FROM data"            '[{x 0} {x 1}]                                                  '[[100.0]]
+    "SELECT percentile_in(x, 0) FROM data"            '[{x 0} {x -1}]                                                 '[[50.0]]
+    "SELECT percentile_in(x, 1) FROM data"            '[{x 0} {x -1}]                                                 '[[100.0]]
+    "SELECT percentile_in(x, 2) FROM data"            '[{x 0} {x 1} {x 3} {x 4}]                                      '[[50.0]]
+    "SELECT percentile_in(x, 1) FROM data"            '[{x 0} {x 2} {x 3} {x 4}]                                      '[[25.0]]
+    "SELECT percentile_in(x, 8) FROM data"            '[{x 0} {x 1} {x 2} {x 3} {x 4} {x 5} {x 6} {x 7} {x 9} {x 10}] '[[80.0]]
+    "SELECT percentile_in(x, 8) FROM data"            '[{x 10} {x 9} {x 7} {x 6} {x 5} {x 4} {x 3} {x 2} {x 1} {x 0}] '[[80.0]]
+    "SELECT percentile_in(x, 1) FROM data GROUP BY y" '[{x 0 y 0} {x 1 y 1} {x 2 y 0} {x 3 y 1}]                      '[[50.0] [0.0]]
+    "SELECT min(x), percentile_in(x, 1) FROM data"    '[{x 0} {x 2}]                                                  '[[0 50.0]]))
+
 (def mmix
   {:vars {:x :categorical
           :y :categorical}


### PR DESCRIPTION
## What does this do?

Adds a new aggregator called `percentile_in` which computes the percentile a certain value `x` in a column `y` corresponds to.

## Why do we want this?

This allows us to compute interesting rank statistics for synthetic and real data.

## How was this tested?

Added a test [here](https://github.com/InferenceQL/inferenceql.query/blob/schaechtle/percentile-of/test/inferenceql/query/plan_test.cljc#L198-L214) that passes.