### PR TITLE
Use inferenceql.inference EDN readers when slurping models

### DIFF
--- a/src/inferenceql/query/db.cljc
+++ b/src/inferenceql/query/db.cljc
@@ -4,11 +4,12 @@
   (:refer-clojure :exclude [empty slurp])
   (:require #?(:clj [clojure.core :as clojure])
             #?(:clj [clojure.edn :as edn])
+            #?(:clj [inferenceql.inference.gpm :as gpm])
             [cognitect.anomalies :as-alias anomalies]))
 
 #?(:clj (defn slurp
           [x]
-          (-> (clojure/slurp x) (edn/read-string))))
+          (edn/read-string {:readers gpm/readers} (clojure/slurp x))))
 
 (defn empty
   []


### PR DESCRIPTION
Most (all?) models in IQL are expressed as Clojure records. Thus, when serialized to EDN they use tagged literals. To deserialize such a model you need to provide `edn/read` (or `edn/read-string`) readers that map the tags back to the records.