### PR TITLE
Remove prompts from shell blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 `inferenceql.query` provides a simple command-line application that allows the user to manually enter and evaluate InferenceQL queries. Usage information can be printed with the following command.
 
 ``` bash
-% clj -M -m inferenceql.query.main --help
+clj -M -m inferenceql.query.main --help
 ```
 
 The command-line application currently supports IQL-strict and IQL-permissive queries, with strict the default.
@@ -19,7 +19,7 @@ The command-line application currently supports IQL-strict and IQL-permissive qu
 If you would like to use `inferenceql.query` to query SPPL models you will need to ensure that SPPL is on the classpath, and that [libpython-clj](https://github.com/clj-python/libpython-clj) can find a Python where SPPL is installed. The easiest way to accomplish this is to use [Nix](https://nixos.org/):
 
 ``` shell
-% nix develop github:inferenceql/inferenceql.gpm.sppl -c clj -Sdeps '{:deps {io.github.inferenceql/inferenceql.gpm.sppl {:git/sha "52f8316e094b3644709dccde8f0a935f9b55f187"}}}' -M -m inferenceql.query.main --help
+nix develop github:inferenceql/inferenceql.gpm.sppl -c clj -Sdeps '{:deps {io.github.inferenceql/inferenceql.gpm.sppl {:git/sha "52f8316e094b3644709dccde8f0a935f9b55f187"}}}' -M -m inferenceql.query.main --help
 ```
 
 ### Clojure interface


### PR DESCRIPTION
## Why should we do this?

Currently some of the command-line examples in our `README` begin with `%` which is meant to indicate the end of the user's prompt. While well-intended this makes the command-line examples harder to copy / paste.