### PR TITLE
Add log transform

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -122,6 +122,7 @@ scalar-expr ::= scalar-expr-0
 <scalar-expr-3> ::= scalar-expr-4 | expr-binop
 <scalar-expr-4> ::= scalar-expr-5 | expr-addition | expr-subtraction
 <scalar-expr-5> ::= scalar-expr-6 | expr-multiplication | expr-division
+<scalar-expr-6> ::= scalar-expr-7 | expr-function-call
 
 expr-disjunction ::= scalar-expr-0 ws #'(?i)OR'  ws scalar-expr-1
 expr-conjunction ::= scalar-expr-1 ws #'(?i)AND' ws scalar-expr-2
@@ -135,6 +136,10 @@ expr-subtraction ::= scalar-expr-4 ws? '-' ws? scalar-expr-5
 
 expr-multiplication ::= scalar-expr-5 ws? '*' ws? scalar-expr-6
 expr-division       ::= scalar-expr-5 ws? '/' ws? scalar-expr-6
+
+(* currently only log - will likely add more later *)
+<expr-function-call> ::=  expr-function-call-log
+expr-function-call-log ::= 'log(' ws? scalar-expr-6 ws? ')'
 
 scalar-expr-group ::= '(' ws? scalar-expr ws? ')'
 

--- a/resources/inferenceql/query/permissive.bnf
+++ b/resources/inferenceql/query/permissive.bnf
@@ -1,5 +1,5 @@
 <scalar-expr-0> ::= scalar-expr-1 | expr-disjunction | probability-expr | mutual-info-expr
-<scalar-expr-6> ::= scalar-expr-group | simple-symbol | value
+<scalar-expr-7> ::= scalar-expr-group | simple-symbol | value
 
 (* model-expr *)
 

--- a/resources/inferenceql/query/strict.bnf
+++ b/resources/inferenceql/query/strict.bnf
@@ -1,4 +1,4 @@
-<scalar-expr-6> ::= scalar-expr-group | simple-symbol | value | probability-expr | density-expr | mutual-info-expr | approx-mutual-info-expr
+<scalar-expr-7> ::= scalar-expr-group | simple-symbol | value | probability-expr | density-expr | mutual-info-expr | approx-mutual-info-expr
 
 (* model-expr *)
 

--- a/src/inferenceql/query/scalar.cljc
+++ b/src/inferenceql/query/scalar.cljc
@@ -32,6 +32,8 @@
     [:expr-multiplication left _ right] `(~'*   ~(plan left) ~(plan right))
     [:expr-division       left _ right] `(~'/   ~(plan left) ~(plan right))
 
+    [:expr-function-call-log _log child _] `(~'log ~(plan child))
+
     [:expr-binop left [:binop [:is _]]       right] `(~'=         ~(plan left) ~(plan right))
     [:expr-binop left [:binop [:is-not & _]] right] `(~'not=      ~(plan left) ~(plan right))
     [:expr-binop left [:binop s]             right] `(~(symbol s) ~(plan left) ~(plan right))
@@ -194,7 +196,8 @@
                   '+ (nil-safe (auto-unbox +))
                   '- (nil-safe (auto-unbox -))
                   '* (nil-safe (auto-unbox *))
-                  '/ (nil-safe (auto-unbox /))}
+                  '/ (nil-safe (auto-unbox /))
+                  'log (nil-safe (auto-unbox math/log))}
    'iql {'prob prob
          'pdf pdf
          #?@(:clj ['eval-relation-plan

--- a/test/inferenceql/query/scalar_test.cljc
+++ b/test/inferenceql/query/scalar_test.cljc
@@ -186,3 +186,15 @@
         env {'model model}]
     (eval "APPROXIMATE MUTUAL INFORMATION OF VAR x WITH VAR y UNDER model" env)
     (is (= 1000 @simulate-count))))
+
+(deftest eval-transforms
+  (are [s env expected] (= expected
+                           (try (eval s env)
+                                (catch #?(:clj Exception :cljs :default) e
+                                  :error)))
+    "log(x)" '{x 1} 0.0
+    "log(1)" '{} 0.0
+    "log(0.5)" '{} -0.6931471805599453 ; spot check
+    "log(x)" '{x 0.8} -0.2231435513142097 ; spot check
+    "log(x) - log(y)" '{x 0.5 y 0.2} 0.916290731874155; spot check
+    "log(x)" '{} :error))


### PR DESCRIPTION
## What does this do?

Add `LOG(x)` transforms as scalar expressions.

## Why do we want this?

This allows us to write cool little probability programs like
```
SELECT
  AVG(log_pxy_div_px_py) AS mutual_information
FROM (
  SELECT log(pxy) - log(px) - log(py) AS log_pxy_div_px_py FROM (
    SELECT
        PROBABILITY OF Perigee_km AND Apogee_km UNDER model GIVEN Period_minutes > 2000 AS pxy,
        PROBABILITY OF Perigee_km UNDER model GIVEN Period_minutes > 2000 AS px,
        PROBABILITY OF Apogee_km UNDER model GIVEN Period_minutes > 2000 AS py
    FROM
        (GENERATE * UNDER model GIVEN Period_minutes > 2000)
    LIMIT 1000))
```
## How was this tested?

Added tests to `scalar_test.cljc`

