### PR TITLE
docs: Document the `GENERATIVE JOIN` query

### DIFF
--- a/docs/modules/ROOT/partials/permissive/table-expressions.adoc
+++ b/docs/modules/ROOT/partials/permissive/table-expressions.adoc
@@ -2,6 +2,8 @@ include::partial$base/table-expressions/preamble.adoc[]
 
 include::partial$permissive/table-expressions/generate.adoc[]
 
+include::partial$permissive/table-expressions/generative-join.adoc[]
+
 include::partial$base/table-expressions/insert.adoc[]
 
 include::partial$base/table-expressions/update.adoc[]

--- a/docs/modules/ROOT/partials/permissive/table-expressions/generative-join.adoc
+++ b/docs/modules/ROOT/partials/permissive/table-expressions/generative-join.adoc
@@ -1,0 +1,11 @@
+=== `+GENERATIVE JOIN+`
+
+The `+GENERATIVE JOIN+` expression evaluates to a table by combining a model and a table. Like a join in SQL, a generative join returns a new, larger table. Unlike a join between two tables in SQL, a generative join takes a data table and joins it with conditional samples from a model.
+
+[example]
+====
+[source,iql]
+----
+satellites GENERATIVE JOIN satellites_model GIVEN Users AND Apogee_km AND Perigee_km
+----
+====

--- a/docs/modules/ROOT/partials/strict/table-expressions.adoc
+++ b/docs/modules/ROOT/partials/strict/table-expressions.adoc
@@ -2,6 +2,8 @@ include::partial$base/table-expressions/preamble.adoc[]
 
 include::partial$strict/table-expressions/generate.adoc[]
 
+include::partial$strict/table-expressions/generative-join.adoc[]
+
 include::partial$base/table-expressions/insert.adoc[]
 
 include::partial$base/table-expressions/update.adoc[]

--- a/docs/modules/ROOT/partials/strict/table-expressions/generative-join.adoc
+++ b/docs/modules/ROOT/partials/strict/table-expressions/generative-join.adoc
@@ -1,0 +1,11 @@
+=== `+GENERATIVE JOIN+`
+
+The `+GENERATIVE JOIN+` expression evaluates to a table by combining a model and a table. Like a join in SQL, a generative join returns a new, larger table. Unlike a join between two tables in SQL, a generative join takes a data table and joins it with conditional samples from a model.
+
+[example]
+====
+[source,iql]
+----
+satellites GENERATIVE JOIN satellites_model CONDITIONED BY VAR Users = Users AND VAR Apogee_km = Apogee_km AND  VAR Perigee_km = Perigee_km
+----
+====


### PR DESCRIPTION
## What does this do?

Documents the generative join query.

## Why do we want this?

Since the generative join query is the first thing we want OSS contributors to try, it's crucial that it's documented.

## How was this tested?

The examples were run with satellites.