### PR TITLE
Add caching

### DIFF
--- a/deps-lock.json
+++ b/deps-lock.json
@@ -1548,6 +1548,16 @@
       "hash": "sha256-hML6t6Mso8HkDEGm7Mm9U26UezBYDne41dwjKjSSXqw="
     },
     {
+      "mvn-path": "org/clojure/core.memoize/1.0.257/core.memoize-1.0.257.jar",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-mg6RgW4hp3SY7+3r1HrUvcL7+X+dvEm8nZWU4gEkbpY="
+    },
+    {
+      "mvn-path": "org/clojure/core.memoize/1.0.257/core.memoize-1.0.257.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-3QQaWFudj1eN30s82rhS8/XdKajjNl4d1ehftl4/c9w="
+    },
+    {
       "mvn-path": "org/clojure/core.rrb-vector/0.0.11/core.rrb-vector-0.0.11.jar",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-Pra50SrtdI0NnMR6u2j3XYouS65rZBycgCOQ5/6GugI="

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,8 @@
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         ring/ring-core {:mvn/version "1.9.5"}
         ring/ring-jetty-adapter {:mvn/version "1.9.5"}
-        tech.tablesaw/tablesaw-core {:mvn/version "0.43.1"}}
+        tech.tablesaw/tablesaw-core {:mvn/version "0.43.1"}
+        org.clojure/core.memoize {:mvn/version "1.0.257"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.13"}

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
     "shadow-cljs": "^2.27.5"
   },
   "dependencies": {
+    "memoizee": "^0.4.15"
   }
 }

--- a/src/inferenceql/query/cache.cljc
+++ b/src/inferenceql/query/cache.cljc
@@ -1,0 +1,20 @@
+(ns inferenceql.query.cache
+  "For caching expensive results."
+  (:require #?(:clj [clojure.core.memoize :as memo]
+               :cljs ["memoizee" :as memoizee])
+            [clojure.string :as string]))
+
+(def default-threshold 100)
+
+
+(defn lru
+  "Memoizes a fn with a least-recently-used eviction policy.
+
+  After the number of cached results exceeds the threshold, the
+  least-recently-used ones will be evicted."
+  ([f]
+   (lru f default-threshold))
+  ([f lru-threshold]
+   #?(:clj (memo/lru f :lru/threshold lru-threshold)
+      :cljs (memoizee f #js {"max" lru-threshold
+                             "normalizer" js/JSON.stringify}))))

--- a/test/inferenceql/query/cache_test.cljc
+++ b/test/inferenceql/query/cache_test.cljc
@@ -1,0 +1,37 @@
+(ns inferenceql.query.cache-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [inferenceql.query.cache :as cache]))
+
+(deftest basic-caching
+  (let [cache-size 2
+        a (atom 0)
+        incrementer (fn [_ignored-but-cached-key]
+                      (swap! a inc))
+        cached-incrementer (cache/lru incrementer cache-size)]
+
+    (is (= 1 (cached-incrementer :foo)))
+    (is (= 2 (cached-incrementer :bar)))
+
+    (is (= 1 (cached-incrementer :foo)))
+    (is (= 2 (cached-incrementer :bar)))
+
+    (is (= 3 (cached-incrementer :moop)))
+
+    ;; cache cleared for :foo
+    (is (= 4 (cached-incrementer :foo)))))
+
+(deftest disambiguate-between-0-and-nil
+  (let [cache-size 1000
+        englishize (fn [x]
+                     (case x
+                       0 "zero"
+                       nil "nil"
+                       "other"))
+        cached-englishize (cache/lru englishize cache-size)]
+    ;; Add them both.
+    (is (= "zero" (cached-englishize 0)))
+    (is (= "nil" (cached-englishize nil)))
+
+    ;; Check that they return the correct values.
+    (is (= "zero" (cached-englishize 0)))
+    (is (= "nil" (cached-englishize nil)))))


### PR DESCRIPTION
Add caching, tests, and cache scalar `pdf/prob/condition/constrain/mutual-info` fns in clj

Also bump up inferenceql.inference version to avoid arrow constructor bug

### Notes 
CLJS does not have core.cache or core.memoize. And in Js, there were surprisingly few comprehensive options for caching, so I went with one that seemed popular, well-maintained, and flexible enough to handle custom keys.

The Clojure `hash` fn hashes both 0 and nil to the same value. Thus hash alone cannot distinguish between `{:x 0}` and `{:x nil}`. (Hash maps have fallbacks to handle collisions, and disambiguate between 0 and nil, but these don't work with most Js cache implementations afaict.)

There are two popular solutions to this problem:
1. Rely on identity. This might work well, given persistent data structures, at the cost of cache misses on different vars with identical contents.
2. Use JSON/stringify. Recommended, and should be pretty optimized under modern browsers. May need to revisit if benchmarks show otherwise.